### PR TITLE
Add Docker support with MySQL integration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+# MySQL
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=book_store_app
+
+# Spring Boot
+SPRING_DATASOURCE_URL=jdbc:mysql://mysql-db:3306/book_store_app?serverTimezone=UTC
+SPRING_DATASOURCE_USERNAME=root
+SPRING_DATASOURCE_PASSWORD=root
+
+# JWT
+JWT_EXPIRATION=30000000
+JWT_SECRET=jabfajbfjabfjsdnjnsmkcdxksutrioerrtf6ydfctf76e845rtfgy785gigsgdsgdcvcsdfcsecsefsedsxzcvsd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk-slim
+WORKDIR /application
+COPY target/bookstore-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,30 @@
+services:
+  mysql-db:
+    image: mysql:8.1
+    container_name: mysql-db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: book_store_app
+    ports:
+      - "3307:3307"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  book-store-app:
+    build: .
+    container_name: book-store-app
+    ports:
+      - "8081:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://host.docker.internal:3306/book_store_app?serverTimezone=UTC
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root
+      JWT_SECRET: jabfajbfjabfjsdnjnsmkcdxksutrioerrtf6ydfctf76e845rtfgy785gigsgdsgdcvcsdfcsecsefsedsxzcvsd
+      JWT_EXPIRATION: 30000000
+    depends_on:
+      mysql-db:
+        condition: service_healthy

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <layers>
+                        <enabled>true</enabled>
+                    </layers>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,18 +1,18 @@
 spring.application.name=book-store-app
-spring.datasource.url=jdbc:mysql://localhost:3306/book_store_app?serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=root
+
+spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:mysql://host.docker.internal:3306/book_store_app?serverTimezone=UTC}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME:root}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:root}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.show-sql=true
 server.servlet.context-path=/api
+
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.yaml
 
 logging.level.org.springframework.security=DEBUG
 
-jwt.expiration=30000000
-jwt.secret=jabfajbfjabfjsdnjnsmkcdxksutrioerrtf6ydfctf76e845rtfgy785gigsgdsgdcvcsdfcsecsefsedsxzcvsd
-
-
+jwt.expiration=${JWT_EXPIRATION:30000000}
+jwt.secret=${JWT_SECRET:jabfajbfjabfjsdnjnsmkcdxksutrioerrtf6ydfctf76e845rtfgy785gigsgdsgdcvcsdfcsecsefsedsxzcvsd}


### PR DESCRIPTION
Description:
This PR introduces Docker support to the Book Store Spring Boot application to simplify local development and deployment. The following changes are included:
 
- Dockerfile – to build the application container with OpenJDK 17 and run the Spring Boot jar.
- .env – environment variables for database credentials and application configuration.
- docker-compose.yml – defines multi-container setup:
- Spring Boot application container
- MySQL database container
- Updated application configuration to use environment variables for the datasource connection.